### PR TITLE
Modified SBT build to publish to Sonatype

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -40,13 +40,12 @@ You can also use obtain a user's unique ID from a provider without using session
 
 ## Installation
 
-A big thank you to [jonoabroad](https://github.com/jonoabroad) for hosting builds to make using much easier.
+A big thank you to [jonoabroad](https://github.com/jonoabroad) for [hosting builds](https://liftmodules.ci.cloudbees.com/job/Omniauth%20Lift%20Module/) to make using much easier.
 
-    libraryDependencies ++= Seq(
-      "net.liftmodules" %% "omniauth" % "2.4-0.5"
-    )
-
-    resolvers += "Omniauth repo" at "https://repository-liftmodules.forge.cloudbees.com/release"
+    libraryDependencies ++= {
+      val liftVersion = "2.5-M4"
+      Seq( "net.liftmodules" %% "omniauth" % (liftVersion+"-0.7") )
+	}
 
     
 ## Providers

--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,8 @@
 name := "Omniauth"
 
-version := "2.4-0.7"
+liftVersion <<= liftVersion ?? "2.5-SNAPSHOT"
+
+version <<= liftVersion apply { _ + "-0.7-SNAPSHOT" }
 
 organization := "net.liftmodules"
 
@@ -8,28 +10,56 @@ scalaVersion := "2.10.0"
  
 crossScalaVersions := Seq("2.10.0", "2.9.2", "2.9.1-1", "2.9.1")
 
-resolvers += "databinder.net repository" at "http://databinder.net/repo"
+resolvers += "CB Central Mirror" at "http://repo.cloudbees.com/content/groups/public"
 
 resolvers += "Sonatype snapshots" at "http://oss.sonatype.org/content/repositories/snapshots/"
 
-libraryDependencies ++= {
-  val liftVersion = "2.5-SNAPSHOT" 
-  Seq(
-     "net.liftweb"   %% "lift-webkit"  % liftVersion  % "compile->default",
-	"net.databinder" %% "dispatch-core" % "0.8.9",    
-    "net.databinder" %% "dispatch-http" % "0.8.9",
-    "net.databinder" %% "dispatch-oauth" % "0.8.9",    
-    "net.databinder" %% "dispatch-gae" % "0.8.9",    
-    "net.databinder" %% "dispatch-http-json" % "0.8.9"
+libraryDependencies <++= liftVersion { v =>
+  Seq("net.liftweb"   %% "lift-webkit"  % v  % "compile->default",
+	    "net.databinder" %% "dispatch-core" % "0.8.9",    
+      "net.databinder" %% "dispatch-http" % "0.8.9",
+      "net.databinder" %% "dispatch-oauth" % "0.8.9",    
+  	  "net.databinder" %% "dispatch-gae" % "0.8.9",    
+      "net.databinder" %% "dispatch-http-json" % "0.8.9"
     )
 }
 
 //scalacOptions ++= Seq("-feature")
 
- // To publish to the Cloudbees repos:
+publishTo <<= version { _.endsWith("SNAPSHOT") match {
+        case true  => Some("snapshots" at "https://oss.sonatype.org/content/repositories/snapshots")
+        case false => Some("releases" at "https://oss.sonatype.org/service/local/staging/deploy/maven2")
+  }
+ } 
 
-publishTo := Some("liftmodules repository" at "https://repository-liftmodules.forge.cloudbees.com/release/")
- 
-credentials += Credentials( file("/private/liftmodules/cloudbees.credentials") ) 
+credentials += Credentials( file("sonatype.credentials") )
 
+credentials += Credentials( file("/private/liftmodules/sonatype.credentials") )
 
+publishMavenStyle := true
+
+publishArtifact in Test := false
+
+pomIncludeRepository := { _ => false }
+
+pomExtra := (
+        <url>https://github.com/ghostm/lift-omniauth</url>
+        <licenses>
+            <license>
+              <name>Apache 2.0 License</name>
+              <url>http://www.apache.org/licenses/LICENSE-2.0.html</url>
+              <distribution>repo</distribution>
+            </license>
+         </licenses>
+         <scm>
+            <url>git@github.com:ghostm/lift-omniauth.git</url>
+            <connection>scm:git:git@github.com:ghostm/lift-omniauth.git</connection>
+         </scm>
+         <developers>
+            <developer>
+              <id>ghostm</id>
+              <name>Matthew Henderson</name>
+              <url>https://github.com/ghostm</url>
+            </developer>
+         </developers> 
+ )

--- a/project/LiftModule.scala
+++ b/project/LiftModule.scala
@@ -1,0 +1,13 @@
+import sbt._
+import sbt.Keys._
+
+object LiftModuleBuild extends Build {
+
+val liftVersion = SettingKey[String]("liftVersion", "Version number of the Lift Web Framework")
+
+val project = Project("LiftModule", file("."))
+
+}
+
+
+


### PR DESCRIPTION
For your consideration, a change to the build to make `sbt publish` publish to the Sonatype repository rather than the Cloudbees repository.

The Cloudbees repository works fine, but when there's a change in the Lift or Scala version numbers we have to manually mount and create directory structures to allow the module to be published.  We don't have to do this with the Sonatype repositories.

This doesn't change the behaviour of the Cloudbees build.  That will build the project and automatically push snapshots, but it'll push them to the Sonatype snapshot repository.

The downside is that publishing new releases (non-snapshots) to Sonatype is more involved, but we do that for all the classic Lift modules already, so we could include Omniauth in that publishing step if you wanted to.  You can also publish releases yourself: the steps are outlined at https://www.assembla.com/spaces/liftweb/wiki/Releasing_the_modules

For users, the change is that they don't need to include the CloudBees repository as a resolver in their build.
