### PR TITLE
Name now includes Lift Edition.

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -11,7 +11,7 @@ in Boot.scala
     Omniauth.initWithProviders(List(new FacebookProvider("key", "secret")))
     //or init with providers in properties
     OmniauthLib.init
-        
+
 
 in your properties file define your client id (key) and secret for each provider you will use
 
@@ -20,7 +20,7 @@ in your properties file define your client id (key) and secret for each provider
 
 For Facebook provider you can set permissions. For example:
 
-    omniauth.facebookpermissions=email,read_stream    
+    omniauth.facebookpermissions=email,read_stream
 
 After a user has logged into an auth provider you can access data through the session var OmniauthLib.currentAuthMap
 
@@ -42,12 +42,17 @@ You can also use obtain a user's unique ID from a provider without using session
 
 A big thank you to [jonoabroad](https://github.com/jonoabroad) for [hosting builds](https://liftmodules.ci.cloudbees.com/job/Omniauth%20Lift%20Module/) to make using much easier.
 
-    libraryDependencies ++= {
-      val liftVersion = "2.5-M4"
-      Seq( "net.liftmodules" %% "omniauth" % (liftVersion+"-0.7") )
-	}
+To include this module in your Lift project, update your `libraryDependencies` in `build.sbt` to include:
 
-    
+For *Lift 2.5.x* (Scala 2.9 and 2.10):
+
+    "net.liftmodules" %% "omniauth_2.5" % "0.7"
+
+For *Lift 3.0.x* (Scala 2.10):
+
+    "net.liftmodules" %% "omniauth_3.0" % "0.7-SNAPSHOT"
+
+
 ## Providers
 
 Lift-OmniAuth currently supports the following external providers:

--- a/build.sbt
+++ b/build.sbt
@@ -1,13 +1,17 @@
 name := "Omniauth"
 
-liftVersion <<= liftVersion ?? "2.5-SNAPSHOT"
-
-version <<= liftVersion apply { _ + "-0.7-SNAPSHOT" }
-
 organization := "net.liftmodules"
 
-scalaVersion := "2.10.0" 
- 
+version := "0.7-SNAPSHOT"
+
+liftVersion <<= liftVersion ?? "2.5-SNAPSHOT"
+
+liftEdition <<= liftVersion apply { _.substring(0,3) }
+
+name <<= (name, liftEdition) { (n, e) =>  n + "_" + e }
+
+scalaVersion := "2.10.0"
+
 crossScalaVersions := Seq("2.10.0", "2.9.2", "2.9.1-1", "2.9.1")
 
 resolvers += "CB Central Mirror" at "http://repo.cloudbees.com/content/groups/public"
@@ -15,11 +19,11 @@ resolvers += "CB Central Mirror" at "http://repo.cloudbees.com/content/groups/pu
 resolvers += "Sonatype snapshots" at "http://oss.sonatype.org/content/repositories/snapshots/"
 
 libraryDependencies <++= liftVersion { v =>
-  Seq("net.liftweb"   %% "lift-webkit"  % v  % "compile->default",
-	    "net.databinder" %% "dispatch-core" % "0.8.9",    
+  Seq("net.liftweb"   %% "lift-webkit"  % v  % "provided",
+	    "net.databinder" %% "dispatch-core" % "0.8.9",
       "net.databinder" %% "dispatch-http" % "0.8.9",
-      "net.databinder" %% "dispatch-oauth" % "0.8.9",    
-  	  "net.databinder" %% "dispatch-gae" % "0.8.9",    
+      "net.databinder" %% "dispatch-oauth" % "0.8.9",
+  	  "net.databinder" %% "dispatch-gae" % "0.8.9",
       "net.databinder" %% "dispatch-http-json" % "0.8.9"
     )
 }
@@ -30,7 +34,7 @@ publishTo <<= version { _.endsWith("SNAPSHOT") match {
         case true  => Some("snapshots" at "https://oss.sonatype.org/content/repositories/snapshots")
         case false => Some("releases" at "https://oss.sonatype.org/service/local/staging/deploy/maven2")
   }
- } 
+ }
 
 credentials += Credentials( file("sonatype.credentials") )
 
@@ -61,5 +65,5 @@ pomExtra := (
               <name>Matthew Henderson</name>
               <url>https://github.com/ghostm</url>
             </developer>
-         </developers> 
+         </developers>
  )

--- a/project/LiftModule.scala
+++ b/project/LiftModule.scala
@@ -3,11 +3,10 @@ import sbt.Keys._
 
 object LiftModuleBuild extends Build {
 
-val liftVersion = SettingKey[String]("liftVersion", "Version number of the Lift Web Framework")
+  val liftVersion = SettingKey[String]("liftVersion", "Full version number of the Lift Web Framework")
 
-val project = Project("LiftModule", file("."))
+  val liftEdition = SettingKey[String]("liftEdition", "Lift Edition (short version number to append to artifact name)")
+
+  val project = Project("LiftModule", file("."))
 
 }
-
-
-


### PR DESCRIPTION
This is a simplification to the build to publish the module without the full Lift version in the module version number.  

This means rather than a Lift project depending on...

```
"net.liftmodules" %% "omniauth" % "2.5-M4-0.7"
```

...it instead depends on:

```
"net.liftmodules" %% "omniauth_2.5" % "0.7"
```

This is because the version number (2.5-M4-0.7) is not strictly a valid Maven version number, which causes problems for some people who run their own repository proxy.

Additionally, by including the Lift edition ("2.5") in the name of the module, we do not have the publish the module again for the whole life of Lift 2.5. (Unless the module changes, of course). 

I've made this change to all the "classic" Lift modules (paypal, textile, etc).

To demonstrate this, I've also published Omniauth as a SNAPSHOT:

```
"net.liftmodules" %% "omniauth_2.5" % "0.7-SNAPSHOT"
```

and

```
"net.liftmodules" %% "omniauth_3.0" % "0.7-SNAPSHOT"
```

If you accept this pull request, I'll go ahead and publish omniauith_2.5 version 0.7 as a non-snapshot if you wish.

Apologies: my editor removed some white space at the end of lines in the commit.
