### PR TITLE
Default to lift 2.6-snapshot

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ organization := "net.liftmodules"
 
 version := "0.7-SNAPSHOT"
 
-liftVersion <<= liftVersion ?? "2.5-SNAPSHOT"
+liftVersion <<= liftVersion ?? "2.6-SNAPSHOT"
 
 liftEdition <<= liftVersion apply { _.substring(0,3) }
 


### PR DESCRIPTION
so that cloudbees can build this module for scala 2.10

The last few builds failed because sbt tried to find lift 2.5-snapshot for scala 2.10 and it doesn't find it.

Thanks
