### PR TITLE
remove non scala 2.10 builds.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -12,8 +12,6 @@ name <<= (name, liftEdition) { (n, e) =>  n + "_" + e }
 
 scalaVersion := "2.10.0"
 
-crossScalaVersions := Seq("2.10.0", "2.9.2", "2.9.1-1", "2.9.1")
-
 resolvers += "CB Central Mirror" at "http://repo.cloudbees.com/content/groups/public"
 
 resolvers += "Sonatype snapshots" at "http://oss.sonatype.org/content/repositories/snapshots/"


### PR DESCRIPTION
String interpolation is being used which isn't supported by Scala 2.9
