### PR TITLE
OmniAuth now keeps all the data about a Google user.

### DIFF
--- a/src/main/scala/omniauth/Omniauth.scala
+++ b/src/main/scala/omniauth/Omniauth.scala
@@ -191,4 +191,5 @@ case class AuthInfo(provider:String,
                     nickName:Option[String] = None,
                     email:Option[String] = None,
                     firstName:Option[String]=None,
-                    lastName:Option[String]=None)
+                    lastName:Option[String]=None,
+                    extraData:Option[Map[String, Any]]=None)

--- a/src/main/scala/omniauth/lib/GoogleProvider.scala
+++ b/src/main/scala/omniauth/lib/GoogleProvider.scala
@@ -77,13 +77,22 @@ class GoogleProvider(val clientId:String, val secret:String) extends OmniauthPro
     try{
       val json = Omniauth.http(tempRequest >- JsonParser.parse)
 
-      val uid =  (json \ "id").extract[String]
-      val name =  (json \ "name").extract[String]
-      val firstName = (json \ "given_name").extract[String]
-      val lastName = (json \ "family_name").extract[String]
-      val email = (json \ "email").extract[String]
+      val uid       =  (json \ "id"        ).extract[String]
+      val name      =  (json \ "name"      ).extract[String]
+      val firstName = (json \ "given_name" ).extract[String]
+      val lastName  = (json \ "family_name").extract[String]
+      val email     = (json \ "email"      ).extract[String]
+      val extraData:Map[String, Any] = List(
+          ("verified_email", (json \ "verified_email").extractOpt[Boolean]),
+          ("link"          , (json \ "link"          ).extractOpt[String]),
+          ("picture"       , (json \ "picture"       ).extractOpt[String]),
+          ("gender"        , (json \ "gender"        ).extractOpt[String]),
+          ("locale"        , (json \ "locale"        ).extractOpt[String]),
+          ("hd"            , (json \ "hd"            ).extractOpt[String])).
+          filter(_._2.isDefined).map(item => (item._1, item._2.get)).
+          toMap
       val ai = AuthInfo(providerName,uid,name,accessToken,Some(secret),
-        Some(name), Some(email), Some(firstName), Some(lastName))
+        Some(name), Some(email), Some(firstName), Some(lastName), Some(extraData))
       Omniauth.setAuthInfo(ai)
       logger.debug(ai)
 


### PR DESCRIPTION
At least for Google, a lot of metadata is just discarded by Omniauth, which is a shame because:
1. That data could actually be useful, like `picture` or `link`,
2. OmniAuth is just fantastic and does so many things automagically that it's just wasteful for it to discard stuff.

But there's no way of systematizing that information. So what to do?

I'm creating a Map[String, Any] for all the extra data. Then, I can just put all the extra data in there. In my Lift app, I can use the data I need and just ignore the rest.

At least it worked for me.
