### PR TITLE
Upgrading Facebook api from v2.3 to v2.4

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,45 +1,43 @@
+import LiftModule.{liftVersion, liftEdition}
+
 name := "Omniauth"
 
 organization := "net.liftmodules"
 
 homepage := Some(url("https://github.com/ghostm/lift-omniauth"))
 
-version := "0.17"
+version := "0.18"
 
-liftVersion <<= liftVersion ?? "2.5.1"
+liftVersion := "3.1.0"
 
-liftEdition <<= liftVersion apply { _.substring(0,3) }
+liftEdition := liftVersion.value.substring(0,3)
 
-name <<= (name, liftEdition) { (n, e) =>  n + "_" + e }
+name := name.value + "_" + liftEdition.value
 
-// Necessary beginning with sbt 0.13, otherwise Lift editions get messed up.
-// E.g. "2.5" gets converted to "2-5"
 moduleName := name.value.toLowerCase
 
-scalaVersion <<= scalaVersion ?? "2.9.1"  // This project's scala version is purposefully set at the lowest common denominator to ensure each version compiles.
+scalaVersion := "2.11.11"
 
-crossScalaVersions := Seq("2.10.4", "2.9.2", "2.9.1-1", "2.9.1") // Excluding "2.11.1" since Lift 2.5.1 isn't built for it
-
-resolvers += "CB Central Mirror" at "http://repo.cloudbees.com/content/groups/public"
+crossScalaVersions := Seq("2.11.11", "2.12.2")
 
 resolvers += "Sonatype snapshots" at "http://oss.sonatype.org/content/repositories/snapshots/"
 
-libraryDependencies <++= liftVersion { v =>
-  Seq("net.liftweb"   %% "lift-webkit"  % v  % "provided",
-      "net.databinder" %% "dispatch-core" % "0.8.10",
-      "net.databinder" %% "dispatch-http" % "0.8.10",
-      "net.databinder" %% "dispatch-oauth" % "0.8.10",
-      "net.databinder" %% "dispatch-http-json" % "0.8.10"
-    )
-}
+libraryDependencies++= Seq(
+  "net.liftweb"   %% "lift-webkit"  % liftVersion.value  % "provided",
+  "net.databinder" %% "dispatch-core" % "0.8.10",
+  "net.databinder" %% "dispatch-http" % "0.8.10",
+  "net.databinder" %% "dispatch-oauth" % "0.8.10",
+  "net.databinder" %% "dispatch-http-json" % "0.8.10"
+)
+
 
 //scalacOptions ++= Seq("-feature")
 
-publishTo <<= version { _.endsWith("SNAPSHOT") match {
+publishTo := (version.value.endsWith("SNAPSHOT") match {
         case true  => Some("snapshots" at "https://oss.sonatype.org/content/repositories/snapshots")
         case false => Some("releases" at "https://oss.sonatype.org/service/local/staging/deploy/maven2")
   }
- }
+)
 
 credentials += Credentials( file("sonatype.credentials") )
 

--- a/project/LiftModule.scala
+++ b/project/LiftModule.scala
@@ -1,7 +1,7 @@
 import sbt._
 import sbt.Keys._
 
-object LiftModuleBuild extends Build {
+object LiftModule {
 
   val liftVersion = SettingKey[String]("liftVersion", "Full version number of the Lift Web Framework")
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.5
+sbt.version=0.13.15

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,11 +1,9 @@
-resolvers += Classpaths.typesafeResolver
-
-addSbtPlugin("com.typesafe.sbteclipse" % "sbteclipse-plugin" % "2.5.0")
+resolvers += Classpaths.typesafeReleases
 
 //addSbtPlugin("net.databinder" % "posterous-sbt" % "0.3.2")
 //resolvers += "Sonatype snapshots" at "http://oss.sonatype.org/content/repositories/snapshots/"
 
-//addSbtPlugin("com.github.mpeltonen" % "sbt-idea" % "1.2.0-SNAPSHOT")
+addSbtPlugin("com.github.mpeltonen" % "sbt-idea" % "1.6.0")
 
 addSbtPlugin("me.lessis" % "ls-sbt" % "0.1.3")
 

--- a/publish.txt
+++ b/publish.txt
@@ -3,13 +3,9 @@ alias pub=publishSigned
 clean
 
 set liftVersion  in ThisBuild:="3.0-SNAPSHOT"
-set crossScalaVersions := Seq("2.11.4")
+set crossScalaVersions := Seq("2.11.11")
 + pub
 
-set liftVersion  in ThisBuild:="2.6"
-set crossScalaVersions := Seq("2.11.4", "2.10.4", "2.9.2", "2.9.1-1", "2.9.1")
-+ pub
-
-set liftVersion  in ThisBuild:="2.5.1"
-set crossScalaVersions := Seq("2.10.4", "2.9.2", "2.9.1-1", "2.9.1")
+set liftVersion  in ThisBuild:="3.1.0"
+set crossScalaVersions := Seq("2.11.11", "2.12.2")
 + pub

--- a/src/main/scala/omniauth/lib/FacebookProvider.scala
+++ b/src/main/scala/omniauth/lib/FacebookProvider.scala
@@ -101,7 +101,7 @@ class FacebookProvider(val clientId:String, val secret:String) extends OmniauthP
   }
 
   def validateToken(accessToken:AuthToken): Boolean = {
-    val tempRequest = :/("graph.facebook.com").secure / "me" <<? Map("access_token" -> accessToken.token)
+    val tempRequest = :/("graph.facebook.com").secure / "me" <<? Map("fields" -> "id,email,name,first_name,last_name", "access_token" -> accessToken.token)
     try{
       val json = Omniauth.http(tempRequest >- JsonParser.parse)
 

--- a/src/main/scala/omniauth/lib/FacebookProvider.scala
+++ b/src/main/scala/omniauth/lib/FacebookProvider.scala
@@ -122,7 +122,7 @@ class FacebookProvider(val clientId:String, val secret:String) extends OmniauthP
   }
 
   def tokenToId(accessToken:AuthToken): Box[String] = {
-    val tempRequest = :/("graph.facebook.com").secure / "me" <<? Map("access_token" -> accessToken.token)
+    val tempRequest = :/("graph.facebook.com").secure / "me" <<? Map("fields" -> "id", "access_token" -> accessToken.token)
     try{
       val json = Omniauth.http(tempRequest >- JsonParser.parse)
       Full((json \ "id").extract[String])


### PR DESCRIPTION
In the past, responses from Graph API calls returned a set of default fields. In order to reduce payload size and improve latency on mobile networks we have reduced the number of default fields returned for most Graph API calls. In v2.4 you will need to declaratively list the response fields for your calls.